### PR TITLE
Add ACME server parameter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ SL_VERSION=3.4.0
 
 ACME_CHALLENGE=DNS-01
 ACME_SH_DNS_API=dns_azure
+ACME_SERVER=zerossl
 LE_STAGING=true
 
 # Azure DNS credentials

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ Set the following variables in `.env` to appropriate values:
 
 - set the `LE_STAGING` to `true` or `false`.
 - set the `ACME_CHALLENGE` variable to either `DNS-01` (default) or `HTTP-01`.
+- set the `ACME_SERVER` variable to any of the [supported servers by acme.sh](https://github.com/acmesh-official/acme.sh/wiki/Server). Default value is `zerossl`.
 
 If you are using DNS-01 ACME challenge, set `ACME_SH_DNS_API` to one of the
 [supported acme.sh DNS API](https://github.com/acmesh-official/acme.sh#8-automatic-dns-api-integration) plugins.

--- a/acme.sh/Dockerfiles/docker-entrypoint.sh
+++ b/acme.sh/Dockerfiles/docker-entrypoint.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 challenge="${ACME_CHALLENGE}"
-dns_api=${ACME_SH_DNS_API}
+dns_api="${ACME_SH_DNS_API}"
+server="${ACME_SERVER}"
 staging="${LE_STAGING}"
 
-request_zerossl_certificate() {
+request_server_certificate() {
 
-  params=( acme.sh --issue --force --log --renew-hook \"docker restart nginx\" --email contact@$DOMAIN )
+  params=( acme.sh --issue --force --log --renew-hook \"docker restart nginx\" --email contact@$DOMAIN --server $server )
 
   if [ $staging = 'true' ]; then
     params=( "${params[@]}" --debug --staging)
@@ -14,16 +15,16 @@ request_zerossl_certificate() {
 
   if [ $challenge = 'HTTP-01' ]; then
 
-    echo 'Requesting bootstrap zerossl certificates using HTTP-01 ACME challenge'
+    echo 'Requesting bootstrap certificates using HTTP-01 ACME challenge'
     params=( "${params[@]}" --domain $DOMAIN --domain app.$DOMAIN --domain mta-sts.$DOMAIN \ --webroot /var/www/ )
-    
+
   fi
 
   if [ $challenge = 'DNS-01' ]; then
 
-    echo 'Requesting bootstrap zerossl certificates using DNS-01 ACME challenge using acme.sh DNS API'
+    echo "Requesting bootstrap $server certificates using DNS-01 ACME challenge using acme.sh DNS API"
     params=( "${params[@]}" --domain *.$DOMAIN --domain $DOMAIN --dns $dns_api )
-    
+
   fi
 
   echo "${params[@]}"
@@ -33,8 +34,8 @@ request_zerossl_certificate() {
 }
 
 
-renew_zerossl_certificate() {
-  echo 'Renewing zerossl certificate...'
+renew_server_certificate() {
+  echo "Renewing $server certificate..."
   acme.sh --cron
 }
 
@@ -43,12 +44,11 @@ if [ $challenge = 'HTTP-01' ]; then
   directory_path="/root/.acme.sh/${DOMAIN}_ecc"
 fi
 
-[ -d "$directory_path" ] || request_zerossl_certificate
+[ -d "$directory_path" ] || request_server_certificate
 
 trap exit TERM
 while :
 do
-  renew_zerossl_certificate
+  renew_server_certificate
   sleep 6h
 done
-

--- a/acme.sh/Dockerfiles/docker-entrypoint.sh
+++ b/acme.sh/Dockerfiles/docker-entrypoint.sh
@@ -7,6 +7,10 @@ staging="${LE_STAGING}"
 
 request_server_certificate() {
 
+  if [ -z "$server" ]; then
+    server="zerossl"
+  fi
+
   params=( acme.sh --issue --force --log --renew-hook \"docker restart nginx\" --email contact@$DOMAIN --server $server )
 
   if [ $staging = 'true' ]; then


### PR DESCRIPTION
This PR adds the `--server` parameter to `acme.sh` to let the user choose which ACME server to use.