### PR TITLE
Enforced HSTS

### DIFF
--- a/simple-login-compose.yaml
+++ b/simple-login-compose.yaml
@@ -75,12 +75,7 @@ services:
       - traefik.http.routers.${LE_CHALLENGE:-tls}.middlewares=redir,sts
       - traefik.http.middlewares.redir.redirectregex.regex=^https?://${DOMAIN}/?.*
       - traefik.http.middlewares.redir.redirectregex.replacement=https://${SUBDOMAIN:-app}.${DOMAIN}
-      ## add STS Header for $DOMAIN and all subdomains
-      - traefik.http.middlewares.sts.headers.stsSeconds=31536000
-      - traefik.http.middlewares.sts.headers.forceSTSHeader=true 
-      - traefik.http.middlewares.sts.headers.stsPreload=true
-      - traefik.http.middlewares.sts.headers.stsIncludeSubdomains=true
-      ## static response for `mta-sts` subdomain 
+      ## static response for `mta-sts` subdomain
       - traefik.http.routers.mta-sts.rule=Host("mta-sts.${DOMAIN}") && PathPrefix("/.well-known/mta-sts.txt")
       - traefik.http.routers.mta-sts.service=noop@internal
       - traefik.http.routers.mta-sts.middlewares=mta-sts

--- a/traefik-compose.yaml
+++ b/traefik-compose.yaml
@@ -19,10 +19,12 @@ services:
       - --global.sendanonymoususage=false
       - --providers.docker.exposedByDefault=false
       - --providers.docker.network=traefik
+      - --providers.file.directory=/etc/traefik/middlewares
       - --entrypoints.web.address=:80
       - --entrypoints.web.http.redirections.entrypoint.to=websecure
       - --entrypoints.web.http.redirections.entrypoint.scheme=https
       - --entrypoints.websecure.address=:443
+      - --entrypoints.websecure.http.middlewares=hsts@file
       - --entrypoints.websecure.http.tls.certresolver=${LE_CHALLENGE:-tls}
       - --certificatesresolvers.tls.acme.storage=/etc/traefik/acme/acme-tls.json
       - --certificatesresolvers.tls.acme.email=${LE_EMAIL:-${SUPPORT_EMAIL:-support@${DOMAIN}}}
@@ -47,6 +49,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - traefik-acme:/etc/traefik/acme
+      - ./traefik/middlewares/:/etc/traefik/middlewares/:ro
     extra_hosts:
       - host.docker.internal:host-gateway
     healthcheck:

--- a/traefik/middlewares/hsts.yaml
+++ b/traefik/middlewares/hsts.yaml
@@ -1,0 +1,9 @@
+http:
+  middlewares:
+    hsts:
+      headers:
+        sslRedirect: true
+        stsSeconds: 31536000
+        stsIncludeSubdomains: true
+        stsPreload: false
+        forceSTSHeader: true


### PR DESCRIPTION
The current labels on the `app` service do not seem to work.

This pull request adds a file-based configuration for HSTS.
**Note**: HSTS preloading is **not** enabled as this requires extra infrastructure.

