### PR TITLE
Various postfix security-related options

### DIFF
--- a/postfix/conf.d/main.cf.tpl
+++ b/postfix/conf.d/main.cf.tpl
@@ -68,5 +68,5 @@ smtpd_recipient_restrictions =
 # Log output
 maillog_file=/dev/stdout
 
-virtual_alias_domains =
+virtual_alias_domains = 
 virtual_alias_maps = lmdb:/etc/postfix/conf.d/virtual, regexp:/etc/postfix/conf.d/virtual-regexp


### PR DESCRIPTION
# VRFY

https://linux-audit.com/postfix-hardening-guide-for-security-and-privacy/#disable-vrfy-verify

- `disable_vrfy_command = yes`

