### PR TITLE
Removed incomplete support for dane/dnssec

### DIFF
--- a/postfix/docker-entrypoint.sh
+++ b/postfix/docker-entrypoint.sh
@@ -64,19 +64,6 @@ if [ -s $CERT_DOMAIN.fullchain.pem ] && ( [ ! -s $CERT_SUB.fullchain.pem ] || ha
   sed -i -e "s,${CERT_SUB},${CERT_DOMAIN},g" "$MAIL_CONFIG/main.cf"
 fi
 
-if dig +short DS "${DOMAIN}" | grep -q .; then
-  # Enable DNSSEC in Postfix
-  sed -i \
-      -e 's/^smtp_dns_support_level.*/smtp_dns_support_level = dnssec/' \
-      "$MAIL_CONFIG/main.cf"
-
-  # If entry does not exist, append it
-  grep -q "^smtp_dns_support_level" "$MAIL_CONFIG/main.cf" || \
-      echo "smtp_dns_support_level = dnssec" >> "$MAIL_CONFIG/main.cf"
-
-  echo "DNSSEC DS record found for ${DOMAIN}: Postfix updated, DNSSEC enabled."
-fi
-
 # generate optional files only if they do not exist
 [ -f "$MAIL_CONFIG/virtual" ] || \
   sed -e "s/domain.tld/${DOMAIN}/g" \


### PR DESCRIPTION
[`smtp_dns_support_level = dnssec`](https://www.postfix.org/postconf.5.html#smtp_dns_support_level) is a client-side setting (meaning that SL will try and lookup domain names using DNS and check if the DNS records are trust worthy using DNSSEC.

This seems unrelated to the fact that SL might be exposed from a domain whose DNS Zone is protected using DNSSEC.

This PR removes DNSSEC support as setting this up seems complex and it is suggested in the docs that we need our own nameserver as well, which seems overkill for self-hosting SL.