### PR TITLE
Change starting order/dependencies, add Healthchecks, expose only port 25

### DIFF
--- a/postfix-compose.yaml
+++ b/postfix-compose.yaml
@@ -13,13 +13,20 @@ services:
     env_file: .env
     ports:
       - '25:25'
-      - '587:587'
     volumes:
       - certs:/certs:ro
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "nc -w 3 127.0.0.1 25 </dev/null | grep -q '^220'"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
-      - email
-      - traefik-certificate-exporter
+      postgres:  
+        condition: service_healthy
+      traefik-certificate-exporter:
+        condition: service_healthy
     labels:
       - com.github.ravensorb.traefik-certificate-exporter.domain-restart=${SUBDOMAIN:-app}.${DOMAIN},${DOMAIN}
 
@@ -37,12 +44,18 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - traefik-acme:/data:ro
       - certs:/certs:rw
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f \"/certs/${SUBDOMAIN:-app}.${DOMAIN}.fullchain.pem\" ] || [ -f \"/certs/${DOMAIN}.fullchain.pem\" ]"]
+      interval: 20s
+      timeout: 5s
+      retries: 3
+      start_period: 5m
     depends_on:
       - app
 
 volumes:
   certs:
-  ## Uncomment the next lines, if traefik is running outside this project
-  # traefik-acme:  # <-- do not change this identifier
-  #   name: traefik-acme    # change (only) this to the name of traefik acme storage volume
-  #   external: true
+## Uncomment the next lines, if traefik is running outside this project
+#  traefik-acme:  # <-- do not change this identifier
+#    name: traefik-acme    # change (only) this to the name of traefik acme storage volume
+#    external: true

--- a/postfix-compose.yaml
+++ b/postfix-compose.yaml
@@ -23,8 +23,6 @@ services:
       retries: 3
       start_period: 30s
     depends_on:
-      postgres:  
-        condition: service_healthy
       traefik-certificate-exporter:
         condition: service_healthy
     labels:

--- a/postfix-compose.yaml
+++ b/postfix-compose.yaml
@@ -55,7 +55,7 @@ services:
 
 volumes:
   certs:
-## Uncomment the next lines, if traefik is running outside this project
-#  traefik-acme:  # <-- do not change this identifier
-#    name: traefik-acme    # change (only) this to the name of traefik acme storage volume
-#    external: true
+  ## Uncomment the next lines, if traefik is running outside this project
+  # traefik-acme:  # <-- do not change this identifier
+  #   name: traefik-acme    # change (only) this to the name of traefik acme storage volume
+  #   external: true

--- a/postfix/Dockerfile
+++ b/postfix/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=base / /
 FROM alpine AS postfix
 
 # install dependencies
-RUN apk --no-cache add postfix postfix-pgsql openssl bind-tools \
+RUN apk --no-cache add postfix postfix-pgsql openssl bind-tools netcat-openbsd \
   && mkdir -p /templates /etc/postfix/conf.d
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
@@ -24,5 +24,6 @@ COPY conf.d /etc/postfix/conf.d/
 
 ENV MAIL_CONFIG=/etc/postfix/conf.d
 
+EXPOSE 25
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/usr/sbin/postfix", "start-fg"]

--- a/simple-login-compose.yaml
+++ b/simple-login-compose.yaml
@@ -90,6 +90,8 @@ services:
     depends_on:
       init:
         condition: service_completed_successfully
+      postfix:
+        condition: service_healthy
 
   job-runner:
     <<: *sl-defaults
@@ -99,3 +101,5 @@ services:
     depends_on:
       init:
         condition: service_completed_successfully
+      email:
+        condition: service_started

--- a/simple-login-compose.yaml
+++ b/simple-login-compose.yaml
@@ -90,8 +90,6 @@ services:
     depends_on:
       init:
         condition: service_completed_successfully
-      postfix:
-        condition: service_healthy
 
   job-runner:
     <<: *sl-defaults


### PR DESCRIPTION
[Upstream documentation](https://github.com/simple-login/app#run-simplelogin-docker-containers) tells to start postfix first, then email-, then job-runner container. 
We add postgres as dependency to postfix, and add healthchecks to cert-exporter and postfix. So postfix will not start until certificate files are ready, and postfix-dependencies will wait until postfix is started and responding.

MTAs only use port 25 to exchange mails. As connecting/authenticating users (via mail-client and ESMTP submission-protocol) is not a use-case for this project, we do not need port 587.
