### PR TITLE
Reworked dependencies

### DIFF
--- a/postfix-compose.yaml
+++ b/postfix-compose.yaml
@@ -48,6 +48,8 @@ services:
     depends_on:
       dns:
         condition: service_healthy
+      postgres:
+        condition: service_healthy
       traefik-certificate-exporter:
         condition: service_healthy
     labels:

--- a/simple-login-compose.yaml
+++ b/simple-login-compose.yaml
@@ -97,6 +97,8 @@ services:
     depends_on:
       init:
         condition: service_completed_successfully
+      postfix:
+        condition: service_healthy
 
   job-runner:
     <<: *sl-defaults


### PR DESCRIPTION
Following PR[#49], this PR now enforces [strong and explicit dependencies](https://github.com/springcomp/self-hosted-simplelogin/pull/49#pullrequestreview-3767519161) for starting Docker containers.

The dependencies are included in the [reference documentation](https://github.com/springcomp/self-hosted-simplelogin/wiki/Docker).