### PR TITLE
Enabled Postscreen

### DIFF
--- a/postfix/conf.d/master.cf
+++ b/postfix/conf.d/master.cf
@@ -6,142 +6,32 @@
 # Do not forget to execute "postfix reload" after editing this file.
 #
 # ==========================================================================
-# service type  private unpriv  chroot  wakeup  maxproc command + args
-#               (yes)   (yes)   (no)    (never) (100)
+# service  type       private unpriv  chroot  wakeup  maxproc command + args
+#                     (yes)   (yes)   (no)    (never) (100)
 # ==========================================================================
-smtp      inet  n       -       n       -       -       smtpd
-#smtp      inet  n       -       n       -       1       postscreen
-#smtpd     pass  -       -       n       -       -       smtpd
-#dnsblog   unix  -       -       n       -       0       dnsblog
-#tlsproxy  unix  -       -       n       -       0       tlsproxy
-# Choose one: enable submission for loopback clients only, or for any client.
-#127.0.0.1:submission inet n -   n       -       -       smtpd
-#submission inet n       -       n       -       -       smtpd
-#  -o syslog_name=postfix/submission
-#  -o smtpd_tls_security_level=encrypt
-#  -o smtpd_sasl_auth_enable=yes
-#  -o smtpd_tls_auth_only=yes
-#  -o local_header_rewrite_clients=static:all
-#  -o smtpd_reject_unlisted_recipient=no
-#     Instead of specifying complex smtpd_<xxx>_restrictions here,
-#     specify "smtpd_<xxx>_restrictions=$mua_<xxx>_restrictions"
-#     here, and specify mua_<xxx>_restrictions in main.cf (where
-#     "<xxx>" is "client", "helo", "sender", "relay", or "recipient").
-#  -o smtpd_client_restrictions=
-#  -o smtpd_helo_restrictions=
-#  -o smtpd_sender_restrictions=
-#  -o smtpd_relay_restrictions=
-#  -o smtpd_recipient_restrictions=permit_sasl_authenticated,reject
-#  -o milter_macro_daemon_name=ORIGINATING
-# Choose one: enable submissions for loopback clients only, or for any client.
-#127.0.0.1:submissions inet n  -       n       -       -       smtpd
-#submissions     inet  n       -       n       -       -       smtpd
-#  -o syslog_name=postfix/submissions
-#  -o smtpd_tls_wrappermode=yes
-#  -o smtpd_sasl_auth_enable=yes
-#  -o local_header_rewrite_clients=static:all
-#  -o smtpd_reject_unlisted_recipient=no
-#     Instead of specifying complex smtpd_<xxx>_restrictions here,
-#     specify "smtpd_<xxx>_restrictions=$mua_<xxx>_restrictions"
-#     here, and specify mua_<xxx>_restrictions in main.cf (where
-#     "<xxx>" is "client", "helo", "sender", "relay", or "recipient").
-#  -o smtpd_client_restrictions=
-#  -o smtpd_helo_restrictions=
-#  -o smtpd_sender_restrictions=
-#  -o smtpd_relay_restrictions=
-#  -o smtpd_recipient_restrictions=permit_sasl_authenticated,reject
-#  -o milter_macro_daemon_name=ORIGINATING
-#628       inet  n       -       n       -       -       qmqpd
-pickup    unix  n       -       n       60      1       pickup
-cleanup   unix  n       -       n       -       0       cleanup
-qmgr      unix  n       -       n       300     1       qmgr
-#qmgr     unix  n       -       n       300     1       oqmgr
-tlsmgr    unix  -       -       n       1000?   1       tlsmgr
-rewrite   unix  -       -       n       -       -       trivial-rewrite
-bounce    unix  -       -       n       -       0       bounce
-defer     unix  -       -       n       -       0       bounce
-trace     unix  -       -       n       -       0       bounce
-verify    unix  -       -       n       -       1       verify
-flush     unix  n       -       n       1000?   0       flush
-proxymap  unix  -       -       n       -       -       proxymap
-proxywrite unix -       -       n       -       1       proxymap
-smtp      unix  -       -       n       -       -       smtp
-relay     unix  -       -       n       -       -       smtp
-        -o syslog_name=postfix/$service_name
-#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
-showq     unix  n       -       n       -       -       showq
-error     unix  -       -       n       -       -       error
-retry     unix  -       -       n       -       -       error
-discard   unix  -       -       n       -       -       discard
-local     unix  -       n       n       -       -       local
-virtual   unix  -       n       n       -       -       virtual
-lmtp      unix  -       -       n       -       -       lmtp
-anvil     unix  -       -       n       -       1       anvil
-scache    unix  -       -       n       -       1       scache
-postlog   unix-dgram n  -       n       -       1       postlogd
-#
-# ====================================================================
-# Interfaces to non-Postfix software. Be sure to examine the manual
-# pages of the non-Postfix software to find out what options it wants.
-#
-# Many of the following services use the Postfix pipe(8) delivery
-# agent.  See the pipe(8) man page for information about ${recipient}
-# and other message envelope options.
-# ====================================================================
-#
-# maildrop. See the Postfix MAILDROP_README file for details.
-# Also specify in main.cf: maildrop_destination_recipient_limit=1
-#
-#maildrop  unix  -       n       n       -       -       pipe
-#  flags=DRXhu user=vmail argv=/usr/bin/maildrop -d ${recipient}
-#
-# ====================================================================
-#
-# Recent Cyrus versions can use the existing "lmtp" master.cf entry.
-#
-# Specify in cyrus.conf:
-#   lmtp    cmd="lmtpd -a" listen="localhost:lmtp" proto=tcp4
-#
-# Specify in main.cf one or more of the following:
-#  mailbox_transport = lmtp:inet:localhost
-#  virtual_transport = lmtp:inet:localhost
-#
-# ====================================================================
-#
-# Cyrus 2.1.5 (Amos Gouaux)
-# Also specify in main.cf: cyrus_destination_recipient_limit=1
-#
-#cyrus     unix  -       n       n       -       -       pipe
-#  flags=DRX user=cyrus argv=/cyrus/bin/deliver -e -r ${sender} -m ${extension} ${user}
-#
-# ====================================================================
-#
-# Old example of delivery via Cyrus.
-#
-#old-cyrus unix  -       n       n       -       -       pipe
-#  flags=R user=cyrus argv=/cyrus/bin/deliver -e -m ${extension} ${user}
-#
-# ====================================================================
-#
-# See the Postfix UUCP_README file for configuration details.
-#
-#uucp      unix  -       n       n       -       -       pipe
-#  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
-#
-# ====================================================================
-#
-# Other external delivery methods.
-#
-#ifmail    unix  -       n       n       -       -       pipe
-#  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
-#
-#bsmtp     unix  -       n       n       -       -       pipe
-#  flags=Fq. user=bsmtp argv=/usr/sbin/bsmtp -f $sender $nexthop $recipient
-#
-#scalemail-backend unix -       n       n       -       2       pipe
-#  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store
-#  ${nexthop} ${user} ${extension}
-#
-#mailman   unix  -       n       n       -       -       pipe
-#  flags=FRX user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
-#  ${nexthop} ${user}
+anvil      unix       -       -       n       -       1       anvil
+bounce     unix       -       -       n       -       0       bounce
+cleanup    unix       n       -       n       -       0       cleanup
+defer      unix       -       -       n       -       0       bounce
+discard    unix       -       -       n       -       -       discard
+error      unix       -       -       n       -       -       error
+flush      unix       n       -       n       1000?   0       flush
+lmtp       unix       -       -       n       -       -       lmtp
+local      unix       -       n       n       -       -       local
+pickup     unix       n       -       n       60      1       pickup
+postlog    unix-dgram n       -       n       -       1       postlogd
+proxymap   unix       -       -       n       -       -       proxymap
+proxywrite unix       -       -       n       -       1       proxymap
+qmgr       unix       n       -       n       300     1       qmgr
+relay      unix       -       -       n       -       -       smtp
+  -o syslog_name=postfix/$service_name
+retry      unix       -       -       n       -       -       error
+rewrite    unix       -       -       n       -       -       trivial-rewrite
+scache     unix       -       -       n       -       1       scache
+showq      unix       n       -       n       -       -       showq
+smtp       inet       n       -       n       -       -       smtpd
+smtp       unix       -       -       n       -       -       smtp
+tlsmgr     unix       -       -       n       1000?   1       tlsmgr
+trace      unix       -       -       n       -       0       bounce
+verify     unix       -       -       n       -       1       verify
+virtual    unix       -       n       n       -       -       virtual

--- a/postfix/conf.d/master.cf
+++ b/postfix/conf.d/master.cf
@@ -29,9 +29,11 @@ retry      unix       -       -       n       -       -       error
 rewrite    unix       -       -       n       -       -       trivial-rewrite
 scache     unix       -       -       n       -       1       scache
 showq      unix       n       -       n       -       -       showq
-smtp       inet       n       -       n       -       -       smtpd
+smtp       inet       n       -       n       -       1       postscreen
+smtpd      pass       -       -       n       -       -       smtpd
 smtp       unix       -       -       n       -       -       smtp
 tlsmgr     unix       -       -       n       1000?   1       tlsmgr
+tlsproxy   unix       -       -       n       -       0       tlsproxy
 trace      unix       -       -       n       -       0       bounce
 verify     unix       -       -       n       -       1       verify
 virtual    unix       -       n       n       -       -       virtual

--- a/postfix/templates/11-icf-postscreen.tpl
+++ b/postfix/templates/11-icf-postscreen.tpl
@@ -1,0 +1,10 @@
+
+postscreen_bare_newline_enable = yes
+postscreen_bare_newline_action = enforce
+
+postscreen_greet_action = enforce
+
+postscreen_non_smtp_command_enable = yes
+postscreen_non_smtp_command_action = enforce
+
+postscreen_pipelining_enable = yes

--- a/postfix/templates/63-icf-recipient-restrictions.tpl
+++ b/postfix/templates/63-icf-recipient-restrictions.tpl
@@ -18,5 +18,5 @@ smtpd_recipient_restrictions =
   reject_rhsbl_sender your_DQS_key.zrd.dq.spamhaus.net=127.0.2.[2..24],
   reject_rhsbl_helo your_DQS_key.zrd.dq.spamhaus.net=127.0.2.[2..24],
   reject_rhsbl_reverse_client your_DQS_key.zrd.dq.spamhaus.net=127.0.2.[2..24],
-  reject_rbl_client bl.spamcop.net,
+  reject_rbl_client bl.spamcop.net=127.0.0.2,
   permit


### PR DESCRIPTION
This PR adds pre-SMTP checks using [Postscreen(8)](https://www.postfix.org/POSTSCREEN_README.html).

**Note** this PR deliberately does not implement DSNBL checks as these makes the configuration more complex. Those checks would be moved downstream to RSpamd or SpamAssasin milters anyway.