### PR TITLE
Add postfix-runtime volume for queue_directory/data_directory

### DIFF
--- a/postfix-compose.yaml
+++ b/postfix-compose.yaml
@@ -38,6 +38,7 @@ services:
       - '25:25'
     volumes:
       - certs:/certs:ro
+      - postfix-runtime:/postfix-runtime
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "nc -w 3 127.0.0.1 25 </dev/null | grep -q '^220'"]
@@ -80,6 +81,7 @@ services:
 
 volumes:
   certs:
+  postfix-runtime:
   ## Uncomment the next lines, if traefik is running outside this project
   # traefik-acme:  # <-- do not change this identifier
   #   name: traefik-acme    # change (only) this to the name of traefik acme storage volume

--- a/postfix/docker-entrypoint.sh
+++ b/postfix/docker-entrypoint.sh
@@ -118,5 +118,18 @@ else
   echo "Spamhaus DSNBL checks disabled."
 fi
 
+# make sure queue_directory/data_directory (on the postfix-runtime volume) exist
+# and carry correct ownership; "postfix check" creates the queue subdirectory
+# tree, "postfix set-permissions" then fixes ownership/mode on all of it
+QUEUE_DIRECTORY="$(postconf -h queue_directory)"
+DATA_DIRECTORY="$(postconf -h data_directory)"
+mkdir -p "$QUEUE_DIRECTORY" "$DATA_DIRECTORY"
+postfix check
+# Alpine's postfix package ships without /usr/share/doc/postfix, so
+# set-permissions always fails to chown its (nonexistent) readme; that
+# failure is unrelated to queue_directory/data_directory, which get fixed
+# up regardless, so a nonzero exit here is expected and safe to ignore
+postfix set-permissions || true
+
 # hand over to container CMD (postfix start-fg)
 exec "$@"

--- a/postfix/templates/10-icf-main.tpl
+++ b/postfix/templates/10-icf-main.tpl
@@ -5,6 +5,11 @@ biff = no
 compatibility_level = 3.11
 disable_vrfy_command = yes
 
+# queue_directory and data_directory share a single volume
+# (see postfix-runtime volume in postfix-compose.yaml)
+queue_directory = /postfix-runtime/queue
+data_directory = /postfix-runtime/data
+
 # Increase max. mail size limit from default 10M to 25M
 message_size_limit=26214400
 


### PR DESCRIPTION
Postfix's queue_directory (/var/spool/postfix) and data_directory (/var/lib/postfix) previously had no persistent storage, so the mail queue and TLS session caches were lost on every container recreate. Point both at a single postfix-runtime named volume instead, and have the entrypoint create the directory tree and fix ownership on every start via "postfix check" + "postfix set-permissions" (idempotent, so it's safe on both first run and subsequent restarts).

Should be merged before integrating https://github.com/springcomp/self-hosted-simplelogin/pull/55 , so states of all clients (i.e. temp-whitelists) for postscreen survive container restarts, rebuilds, crashes.