### PR TITLE
Whitelist reputable senders via list.dnswl.org in postscreen

### DIFF
--- a/postfix/conf.d/master.cf
+++ b/postfix/conf.d/master.cf
@@ -14,6 +14,7 @@ bounce     unix       -       -       n       -       0       bounce
 cleanup    unix       n       -       n       -       0       cleanup
 defer      unix       -       -       n       -       0       bounce
 discard    unix       -       -       n       -       -       discard
+dnsblog    unix       -       -       n       -       0       dnsblog
 error      unix       -       -       n       -       -       error
 flush      unix       n       -       n       1000?   0       flush
 lmtp       unix       -       -       n       -       -       lmtp

--- a/postfix/templates/11-icf-postscreen.tpl
+++ b/postfix/templates/11-icf-postscreen.tpl
@@ -8,3 +8,17 @@ postscreen_non_smtp_command_enable = yes
 postscreen_non_smtp_command_action = enforce
 
 postscreen_pipelining_enable = yes
+
+# Reputable senders (list.dnswl.org) get a negative score and skip the
+# before-greeting tests + the mandatory first-contact retry entirely,
+# instead of waiting out postscreen_greet_wait on every new source IP —
+# this matters most for big providers (M365, Google, ...) that spread
+# retries across a large, frequently-rotating outbound IP pool, since
+# each such IP otherwise looks "new" to postscreen's own cache.
+postscreen_dnsbl_sites =
+  list.dnswl.org=127.0.[0..255].0*-2,
+  list.dnswl.org=127.0.[0..255].1*-3,
+  list.dnswl.org=127.0.[0..255].2*-4,
+  list.dnswl.org=127.0.[0..255].3*-5
+postscreen_dnsbl_threshold = 1
+postscreen_dnsbl_action = enforce


### PR DESCRIPTION
## Motivation

After enabling postscreen (#55) on a production instance, we observed that mail from several large senders (e.g. Microsoft 365 / Outlook outbound) was either delayed by a significant margin or not delivered within a reasonable time at all.

The cause is postscreen's documented `PASS NEW` behavior: any client postscreen hasn't seen before is disconnected with a temporary `450 4.3.2` after passing the enabled tests, and only allowed straight through to `smtpd` on a subsequent connection. For senders with a small, stable set of outbound IPs this costs one retry and is then cached for `postscreen_cache_retention_time`. For senders that spread retries across a large, frequently-rotating IP pool, every attempt can look "new" to postscreen again, so the delay keeps recurring instead of resolving after the first retry.

## Change

Add `list.dnswl.org` as a reputation source in `postscreen_dnsbl_sites`, weighted negative enough to clear `postscreen_dnsbl_threshold`. Reputable senders (most large providers are listed) then get scored before the greeting and are passed straight to `smtpd`, skipping the mandatory first-contact retry entirely. Unlisted/unknown clients are unaffected and keep going through the existing tests as before.

This also re-adds the `dnsblog(8)` service to `master.cf`, which PR #55 had dropped since it deliberately didn't use any DNSBL/DNSWL scoring — `dnsblog` is what postscreen delegates its DNS-based lookups to.

## Testing

Verified locally with a Docker build of this branch: a compliant test client still receives the standard `450` + `PASS NEW` treatment when unlisted (no regression), and the resolver correctly reaches `list.dnswl.org` and evaluates the response against the configured weight patterns (confirmed via `dnsblog` log output). The container's own healthcheck (loopback, covered by `permit_mynetworks`) is unaffected and still gets an immediate banner.
